### PR TITLE
Add write_strat_res_to_csv_long_format() 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,20 @@
 
 # Project specific
 experiments/results/
+
+#Jiahao Chen
+# Ignore JHC directories anywhere in the repository
+#JHC/
+#**/JHC/
+
+SMAC3/
+benchmarks/
+lib
+results/
+temp.py
+pytorch_env/
+temp/
+
+
+experiments/eva_configs/JHC/
+experiments/syn_configs/JHC/

--- a/JHC/.gitignore
+++ b/JHC/.gitignore
@@ -1,0 +1,4 @@
+other_jobs/
+script/
+slurm_output/
+z3alpha_jobs/

--- a/alphasmt/synthesize.py
+++ b/alphasmt/synthesize.py
@@ -8,7 +8,7 @@ from z3 import *
 from alphasmt.evaluator import SolverEvaluator
 from alphasmt.mcts import MCTS_RUN
 from alphasmt.selector import * 
-from alphasmt.utils import calculatePercentile, write_strat_res_to_csv
+from alphasmt.utils import calculatePercentile, write_strat_res_to_csv, write_strat_res_to_csv_long_format
 
 from alphasmt.strat_tree import PERCENTILES
 VALUE_TYPE = 'par10' # hard code for now
@@ -120,7 +120,8 @@ def cache4stage2(selected_strat, config, stream_logger, log_folder, benchlst = N
         strat_res = s2evaluator.getResLst(strat)
         s2_res_lst.append((strat, strat_res))
     ln_res_csv = os.path.join(log_folder, "ln_res.csv")
-    write_strat_res_to_csv(s2_res_lst, ln_res_csv, s2benchLst)
+    #originally write_strat_res_to_csv(), changed to adapt to the format required by MachSMT
+    write_strat_res_to_csv_long_format(s2_res_lst, ln_res_csv, s2benchLst)
     stream_logger.info(f"Cached results saved to {ln_res_csv}")
     endTime = time.time()
     cacheTime = endTime - startTime

--- a/alphasmt/utils.py
+++ b/alphasmt/utils.py
@@ -1,4 +1,5 @@
 import csv
+import os
 
 def solvedNum(resLst):
     return len([res for res in resLst if res[0]])
@@ -41,6 +42,57 @@ def write_strat_res_to_csv(res_lst, csv_path, bench_lst):
                 else:
                     write_lst.append(-res_tuple[1])
             writer.writerow([strat] + write_lst)
+
+def write_strat_res_to_csv_long_format(res_lst, csv_path, bench_lst):
+    """
+    Writes strategy results to CSV in a long format, differing from write_strat_res_to_csv() in several ways:
+    1. Format: Writes in long format (one row per benchmark-strategy pair) vs wide format (one row per strategy)
+    2. Path handling: Converts relative benchmark paths to absolute paths
+    3. Strategy naming: Creates a mapping between original strategies and simplified names (Z3_strat_0, Z3_strat_1, etc.)
+       and stores this mapping in a separate 'strat_mapping.csv' file in the same directory
+    4. Score calculation: When res_tuple[0] is False, multiplies score by 2 instead of negating it (par2)
+    
+    Input format remains the same:
+    - res_lst: List of tuples (strategy, results)
+    - csv_path: Path where to save the main results CSV
+    - bench_lst: List of benchmark paths (in relative form)
+    
+    Creates two files:
+    1. Main CSV with columns: benchmark,solver,score
+    2. strat_mapping.csv with columns: solver,strategy
+    """
+
+    # Create mapping file path in same directory as csv_path
+    mapping_path = os.path.join(os.path.dirname(csv_path), "strat_mapping.csv")
+    
+    # Create strategy mapping
+    strat_mapping = {}
+    for i, (strat, _) in enumerate(res_lst):
+        strat_mapping[strat] = f"Z3_strat_{i}"
+    
+    # Write strategy mapping to separate CSV
+    with open(mapping_path, 'w') as f:
+        writer = csv.writer(f)
+        writer.writerow(["solver", "strategy"])
+        for strat, solver_name in strat_mapping.items():
+            writer.writerow([solver_name, strat])
+    
+    # Write main results
+    with open(csv_path, 'w') as f:
+        writer = csv.writer(f)
+        # write header
+        writer.writerow(["benchmark", "solver", "score"])
+        
+        # Convert relative paths to absolute paths
+        abs_bench_lst = [os.path.abspath(bench) for bench in bench_lst]
+        
+        # For each strategy and its results
+        for strat, res in res_lst:
+            solver_name = strat_mapping[strat]
+            # For each benchmark and its corresponding result
+            for bench, res_tuple in zip(abs_bench_lst, res):
+                score = res_tuple[1] if res_tuple[0] else res_tuple[1] * 2
+                writer.writerow([bench, solver_name, score])
 
 def read_strat_res_from_csv(csv_path):
     results = []


### PR DESCRIPTION
It saves Z3alpha experiment results in the required input format for MachSMT training.