### PR TITLE
Update line handling for CRLF in SolverRunner and add tests

### DIFF
--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -58,6 +58,14 @@ class TestSolverRunnerExecute(unittest.TestCase):
         self.assertEqual(res, "unsat")
         self.assertEqual(path, SAMPLE_SMT)
 
+    def test_crlf_sat_returns_sat(self) -> None:
+        """Windows Z3 stdout often ends lines with \\r\\n."""
+        runner = SolverRunner("/usr/bin/z3", SAMPLE_SMT, timeout=10, run_id=6)
+        run_id, res, runtime, path = _execute_with_mock(runner, (b"sat\r\n", b""))
+        self.assertEqual(run_id, 6)
+        self.assertEqual(res, "sat")
+        self.assertEqual(path, SAMPLE_SMT)
+
     def test_solver_error_line_returns_error(self) -> None:
         runner = SolverRunner("/usr/bin/z3", SAMPLE_SMT, timeout=10, run_id=5)
         run_id, res, runtime, path = _execute_with_mock(

--- a/z3alpha/evaluator.py
+++ b/z3alpha/evaluator.py
@@ -58,14 +58,14 @@ class SolverRunner:
             )
             return self.run_id, "error", runtime, self.smt_file
 
-        lines = text.rstrip("\n").split("\n")
+        lines = text.splitlines()
         if not lines or not lines[0].strip():
             logger.warning(
                 f"No lines in solver output: {self.solver_path}\ninstance: {self.smt_file}"
             )
             return self.run_id, "error", runtime, self.smt_file
 
-        res = lines[0]
+        res = lines[0].strip()
         if res.startswith("(error"):
             logger.warning(
                 f"Error occurred when solver: {self.solver_path}\n strategy: {self.z3_strategy}\ninstance: {self.smt_file}\nMessage: {res}"


### PR DESCRIPTION
### Changes
* Improved handling of solver output line endings and whitespace, ensuring compatibility with Windows-style CRLF outputs. 
* Changed the parsing logic in `_parse_output` (in `z3alpha/evaluator.py`) to use `splitlines()` instead of manual newline stripping, and to strip whitespace from the result line. This ensures correct handling of both Unix (`\n`) and Windows (`\r\n`) line endings, and removes extra whitespace.
* Added a new test `test_crlf_sat_returns_sat` in `tests/test_evaluator.py` to verify that the parser correctly handles solver output ending with `\r\n`, which is common on Windows.